### PR TITLE
change citizen number to accept a number with as few as 7 digits

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
   acts_as_voter  # thumbs_up gem
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  VALID_CITIZEN_NUMBER_REGEX = /[1-9]\d{7,}/  #TODO what is the portuguese regex for BI/CC number?
+  VALID_CITIZEN_NUMBER_REGEX = /[1-9]\d{6,}/  #TODO what is the portuguese regex for BI/CC number?
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }
   validates :citizen_number, presence: true, format: { with: VALID_CITIZEN_NUMBER_REGEX }, uniqueness: true


### PR DESCRIPTION
older numbers/persons have 7 digits (the first digit is a number between [1-9] and the remaining 6 are any number
